### PR TITLE
fix(group): add validation for groupId in controller

### DIFF
--- a/backend/src/controllers/group.controller.ts
+++ b/backend/src/controllers/group.controller.ts
@@ -54,6 +54,13 @@ export const getGroup = async (req: AuthRequest, res: Response) => {
             });
         }
 
+        if (!groupId || typeof groupId !== "string") {
+            return res.status(400).json({
+                success: false,
+                message: "Group ID is required",
+            });
+        }
+
         const group = await groupService.getGroupChat(groupId, userId);
 
         res.status(200).json({
@@ -122,6 +129,13 @@ export const addMember = async (req: AuthRequest, res: Response) => {
             });
         }
 
+        if (!groupId || typeof groupId !== "string") {
+            return res.status(400).json({
+                success: false,
+                message: "Group ID is required",
+            });
+        }
+
         const result = await groupService.addMemberToGroup(
             groupId,
             userIdToAdd,
@@ -165,6 +179,12 @@ export const removeMember = async (req: AuthRequest, res: Response) => {
             return res.status(400).json({
                 success: false,
                 message: "User ID to remove is required",
+            });
+        }
+        if (!groupId || typeof groupId !== "string") {
+            return res.status(400).json({
+                success: false,
+                message: "Group ID is required",
             });
         }
 
@@ -211,6 +231,13 @@ export const updateGroup = async (req: AuthRequest, res: Response) => {
             return res.status(400).json({
                 success: false,
                 message: "Group name is required",
+            });
+        }
+
+        if (!groupId || typeof groupId !== "string") {
+            return res.status(400).json({
+                success: false,
+                message: "Group ID is required",
             });
         }
 
@@ -268,6 +295,13 @@ export const changeMemberRole = async (req: AuthRequest, res: Response) => {
             });
         }
 
+        if (!groupId || typeof groupId !== "string") {
+            return res.status(400).json({
+                success: false,
+                message: "Group ID is required",
+            });
+        }
+
         const result = await groupService.changeMemberRole(
             groupId,
             userIdToChangeRole,
@@ -305,6 +339,13 @@ export const deleteGroup = async (req: AuthRequest, res: Response) => {
             return res.status(401).json({
                 success: false,
                 message: "Unauthorized",
+            });
+        }
+
+        if (!groupId || typeof groupId !== "string") {
+            return res.status(400).json({
+                success: false,
+                message: "Group ID is required",
             });
         }
 


### PR DESCRIPTION
This pull request improves the robustness of the group controller endpoints by adding explicit validation for the `groupId` parameter in all relevant group-related controller methods. Now, each endpoint checks that `groupId` is present and is a string before proceeding, and returns a clear error message if the validation fails.

Validation improvements in group controller endpoints:

* Added a check to ensure `groupId` is provided and is a string in the following controller methods: `getGroup`, `addMember`, `removeMember`, `updateGroup`, `changeMemberRole`, and `deleteGroup`. Each now returns a 400 error with a descriptive message if the validation fails. [[1]](diffhunk://#diff-1b49802101c84f789c737693d62b64f14f49eafde345f57618e066f3d2378f6fR57-R63) [[2]](diffhunk://#diff-1b49802101c84f789c737693d62b64f14f49eafde345f57618e066f3d2378f6fR132-R138) [[3]](diffhunk://#diff-1b49802101c84f789c737693d62b64f14f49eafde345f57618e066f3d2378f6fR184-R189) [[4]](diffhunk://#diff-1b49802101c84f789c737693d62b64f14f49eafde345f57618e066f3d2378f6fR237-R243) [[5]](diffhunk://#diff-1b49802101c84f789c737693d62b64f14f49eafde345f57618e066f3d2378f6fR298-R304) [[6]](diffhunk://#diff-1b49802101c84f789c737693d62b64f14f49eafde345f57618e066f3d2378f6fR345-R351)